### PR TITLE
Add Docker support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,30 @@
+FROM php:5-apache
+
+##############################################################################
+###	Install PHP extensions from PEAR/PECL:
+###	- MongoDB driver
+###
+### build-essential: needed for PECL to compile
+### php5-dev: needed to provide 'phpize' command
+##############################################################################
+RUN \
+  apt-get update && \
+  DEBIAN_FRONTEND=noninteractive \
+    apt-get -y install \
+      build-essential \
+      php5-dev \
+  && \
+  pecl channel-update pecl.php.net && \
+  pecl install mongo && \
+  rm -vrf /build /tmp/pear && \
+  echo "extension=mongo.so" > /usr/local/etc/php/conf.d/mongo.ini && \
+  DEBIAN_FRONTEND=noninteractive \
+    apt-get -y autoremove --purge \
+      build-essential \
+      php5-dev \
+  && \
+  apt-get autoclean && \
+  apt-get clean && \
+  rm -rf /var/lib/apt/lists/* /var/log/apt/*
+
+ADD . /var/www/html/

--- a/config.php
+++ b/config.php
@@ -33,7 +33,7 @@ class Config {
     /**
      *
      * @var array
-     * @link http://in2.php.net/manual/en/mongoclient.construct.php (for more detail)
+     * @link http://php.net/manual/mongoclient.construct.php (for more detail)
      */
     public static $connection = array(
         'server' => "", //mongodb://localhost:27017


### PR DESCRIPTION
I've also set up an example automated build at https://registry.hub.docker.com/u/pataquets/phpmongodb/ .
You can do a quick test by running this:

```
$ docker run --rm -it --net=host mongo # start a localhost-bound MongoDB node

$ docker run --rm -it --net=host -p 80:80 pataquets/phpmongodb # start a localhost-bound PHPMongoDB container
```

Navigate to http://localhost . Hit CTRL+C on each terminal to stop the respective container. 
PM will see MongoDB because its container shares localhost network stack. To implement Docker best practices, more customizable connection options should be added (e.g. environ vars). 
