### PR TITLE
Wait for entire text to be read

### DIFF
--- a/application/controllers/Collection.php
+++ b/application/controllers/Collection.php
@@ -555,14 +555,18 @@ class CollectionController extends Controller {
             if ($_FILES['import_file']['error'] == UPLOAD_ERR_OK && is_uploaded_file($_FILES['import_file']['tmp_name'])) { //checks that file is uploaded
                 $handle = @fopen($_FILES['import_file']['tmp_name'], "r");
                 if ($handle) {
+		    $aggRecord = "";
                     while (($record = fgets($handle)) !== false) {
-                        $response = $this->getModel()->insert($this->db, $this->collection, $record, 'json');
-                        if ($response['ok'] == 1) {
-                            $this->message->sucess = I18n::t('A_D_I_S');
-                        } else {
-                            $this->message->error = $response['errmsg'];
-                        }
+			$aggRecord .= $record;
                     }
+
+		    $response = $this->getModel()->insert($this->db, $this->collection, $aggRecord, 'json');
+		    if ($response['ok'] == 1) {
+			$this->message->success = I18n::t('A_D_I_S');
+		    } else {
+			$this->message->error = $response['errmsg'];
+		    }
+
                     if (!feof($handle)) {
                         $this->message->error = I18n::t('E_U_F');
                     }

--- a/application/controllers/Collection.php
+++ b/application/controllers/Collection.php
@@ -555,17 +555,17 @@ class CollectionController extends Controller {
             if ($_FILES['import_file']['error'] == UPLOAD_ERR_OK && is_uploaded_file($_FILES['import_file']['tmp_name'])) { //checks that file is uploaded
                 $handle = @fopen($_FILES['import_file']['tmp_name'], "r");
                 if ($handle) {
-		    $aggRecord = "";
+                    $aggRecord = "";
                     while (($record = fgets($handle)) !== false) {
-			$aggRecord .= $record;
+                        $aggRecord .= $record;
                     }
 
-		    $response = $this->getModel()->insert($this->db, $this->collection, $aggRecord, 'json');
-		    if ($response['ok'] == 1) {
-			$this->message->success = I18n::t('A_D_I_S');
-		    } else {
-			$this->message->error = $response['errmsg'];
-		    }
+                    $response = $this->getModel()->insert($this->db, $this->collection, $aggRecord, 'json');
+                    if ($response['ok'] == 1) {
+                        $this->message->success = I18n::t('A_D_I_S');
+                    } else {
+                        $this->message->error = $response['errmsg'];
+                    }
 
                     if (!feof($handle)) {
                         $this->message->error = I18n::t('E_U_F');


### PR DESCRIPTION
The original code took whatever string it got from `$record`, which was usually incomplete, and immediately tried to insert that via MongoDB command. My solution concatenates each `$record` into `$aggRecord` and then inserts the complete `$aggRecord` via MongoDB command.